### PR TITLE
Add Benchmark Script

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,20 +1,54 @@
+import argparse
 import multiprocessing
 import random
+from importlib import import_module
 from itertools import product
 from string import ascii_lowercase
 
 import matplotlib.pyplot as plt
 import numpy as np
 
-from agents.agent8 import Agent
+# ==============
+# Argparse setup
+# ==============
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--agent",
+    "-a",
+    type=int,
+    required=True,
+    help="which agent to use from 1 to 8",
+)
+parser.add_argument(
+    "--trials",
+    "-t",
+    default=50,
+    type=int,
+    help="number of trials per length/shuffle datapoint. defaults to 50",
+)
+parser.add_argument(
+    "--disable-threading",
+    "-d",
+    default=False,
+    action="store_true",
+    help="disable multithreading for benchmarking. makes script run on systems where multithreading isn't working but makes benchmark run more slowly",
+)
+pargs = parser.parse_args()
 
-TRIALS = 50
+agent_name = f"agent{pargs.agent}"
+agent_module = import_module(f".{agent_name}", "agents")
 
 
+# ==================
+# Message Generators
+# ==================
 def get_uniform_message(length: int) -> str:
     return "".join(random.choices(ascii_lowercase, k=length))
 
 
+# ===========================
+# Benchmarking infrastructure
+# ===========================
 def shuffle(n, deck):
     rng = np.random.default_rng()
     shuffles = rng.integers(0, 52, n)
@@ -26,10 +60,10 @@ def shuffle(n, deck):
 
 
 def run_trial(args: tuple[int, int]) -> tuple[int, int, float]:
-    agent = Agent()
+    agent = agent_module.Agent()
     length, n = args
     successes = 0
-    for _ in range(TRIALS):
+    for _ in range(pargs.trials):
         word = get_uniform_message(length)
         deck = agent.encode(word)
         shuffled = shuffle(n, deck)
@@ -37,14 +71,17 @@ def run_trial(args: tuple[int, int]) -> tuple[int, int, float]:
 
         if word == out:
             successes += 1
-    return length, n, successes / TRIALS
+    return length, n, successes / pargs.trials
 
 
 lengths = list(range(1, 11))
 shuffle_amounts = list(range(100))
 work = list(product(lengths, shuffle_amounts))
 pool = multiprocessing.Pool(multiprocessing.cpu_count())
-results = pool.imap_unordered(run_trial, work, chunksize=4)
+if pargs.disable_threading:
+    results = map(run_trial, work)
+else:
+    results = pool.imap_unordered(run_trial, work, chunksize=4)
 
 print("Collecting results...")
 collected_results = {}
@@ -54,6 +91,9 @@ for result in results:
         collected_results[length] = []
     collected_results[length].append((n, recovery_rate))
 
+# ======================
+# Plot benchmark results
+# ======================
 print("Plotting...")
 for length in collected_results:
     ys = [recovery_rate for _, recovery_rate in sorted(collected_results[length])]

--- a/benchmark.py
+++ b/benchmark.py
@@ -167,10 +167,12 @@ for length in collected_results:
     ys = [recovery_rate for _, recovery_rate in sorted(collected_results[length])]
     plt.plot(shuffle_amounts, ys, label=str(length))
 
-plt.legend()
+# https://stackoverflow.com/questions/4700614/how-to-put-the-legend-outside-the-plot
+plt.legend(bbox_to_anchor=(1.04, 1), loc="upper left")
 plt.title(f"Shuffle Count vs. Recovery Rate (Agent {pargs.agent})")
 plt.xlabel("Number of shuffles")
 plt.ylabel("Recovery rate")
+plt.tight_layout()
 plt.savefig("benchmark.png", dpi=300)
 # print(
 #     f"{round((agent.decoding_errors / agent.total_decode) * 100, 2)}% ({agent.decoding_errors}/{agent.total_decode}) decoding errors"

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,52 @@
+import random
+from string import ascii_lowercase
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from agents.agent8 import Agent
+
+TRIALS = 50
+
+
+def get_uniform_message(length: int) -> str:
+    return "".join(random.choices(ascii_lowercase, k=length))
+
+
+def shuffle(n, deck):
+    rng = np.random.default_rng()
+    shuffles = rng.integers(0, 52, n)
+    for pos in shuffles:
+        top_card = deck[0]
+        deck = deck[1:]
+        deck = deck[:pos] + [top_card] + deck[pos:]
+    return deck
+
+
+agent = Agent()
+
+for length in range(1, 11):
+    xs = list(range(100))
+    ys = []
+    for n in xs:
+        successes = 0
+        for _ in range(TRIALS):
+            word = get_uniform_message(length)
+            deck = agent.encode(word)
+            shuffled = shuffle(n, deck)
+            print(f"Shuffled {n} times:", shuffled)
+            out = agent.decode(shuffled)
+
+            if word == out:
+                successes += 1
+                print("success")
+        ys.append(successes / TRIALS)
+    plt.plot(xs, ys, label=str(length))
+plt.legend()
+plt.savefig("benchmark.png", dpi=300)
+plt.title("Exact match recovery rate for uniform random messages of different lengths")
+plt.xlabel("Number of shuffles")
+plt.ylabel("Recovery rate")
+print(
+    f"{round((agent.decoding_errors / agent.total_decode) * 100, 2)}% ({agent.decoding_errors}/{agent.total_decode}) decoding errors"
+)

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,12 +1,33 @@
 import argparse
 import multiprocessing
 import random
+import sys
+from functools import partial
 from importlib import import_module
 from itertools import product
-from string import ascii_lowercase
+from string import ascii_letters, ascii_lowercase, digits, punctuation
 
 import matplotlib.pyplot as plt
 import numpy as np
+
+
+# ==================
+# Message Generators
+# ==================
+def uniform_random_message(character_set: str, length: int) -> str:
+    return "".join(random.choices(character_set, k=length))
+
+
+# ===============
+# Message Domains
+# ===============
+# name -> generator(length)
+MESSAGE_DOMAINS = {
+    "lower": partial(uniform_random_message, ascii_lowercase),
+    "alpha": partial(uniform_random_message, ascii_letters),
+    "alphanum": partial(uniform_random_message, ascii_letters + digits),
+    "password": partial(uniform_random_message, ascii_letters + digits + punctuation),
+}
 
 # ==============
 # Argparse setup
@@ -27,8 +48,41 @@ parser.add_argument(
     help="number of trials per length/shuffle datapoint. defaults to 50",
 )
 parser.add_argument(
-    "--disable-threading",
+    "--min-length",
+    "-L",
+    default=1,
+    type=int,
+    help="minimum message length. defaults to 1",
+)
+parser.add_argument(
+    "--max-length",
+    "-l",
+    default=10,
+    type=int,
+    help="maximum message length. defaults to 10",
+)
+parser.add_argument(
+    "--min-shuffles",
+    "-N",
+    default=0,
+    type=int,
+    help="minimum shuffle amount. defaults to 0",
+)
+parser.add_argument(
+    "--max-shuffles",
+    "-n",
+    default=100,
+    type=int,
+    help="maximum shuffle amount. defaults to 100",
+)
+parser.add_argument(
+    "--domain",
     "-d",
+    default="lower",
+    help="message domain. one of: " + ", ".join(MESSAGE_DOMAINS.keys()),
+)
+parser.add_argument(
+    "--disable-threading",
     default=False,
     action="store_true",
     help="disable multithreading for benchmarking. makes script run on systems where multithreading isn't working but makes benchmark run more slowly",
@@ -37,13 +91,6 @@ pargs = parser.parse_args()
 
 agent_name = f"agent{pargs.agent}"
 agent_module = import_module(f".{agent_name}", "agents")
-
-
-# ==================
-# Message Generators
-# ==================
-def get_uniform_message(length: int) -> str:
-    return "".join(random.choices(ascii_lowercase, k=length))
 
 
 # ===========================
@@ -59,37 +106,58 @@ def shuffle(n, deck):
     return deck
 
 
+# Suppress stdout
+# https://stackoverflow.com/questions/2828953/silence-the-stdout-of-a-function-in-python-without-trashing-sys-stdout-and-resto
+class DummyFile(object):
+    def write(self, x):
+        pass
+
+    def flush(self):
+        pass
+
+
 def run_trial(args: tuple[int, int]) -> tuple[int, int, float]:
+    # Suppress stdout
+    save_stdout = sys.stdout
+    sys.stdout = DummyFile()
+
     agent = agent_module.Agent()
     length, n = args
     successes = 0
     for _ in range(pargs.trials):
-        word = get_uniform_message(length)
+        word = MESSAGE_DOMAINS[pargs.domain](length)
         deck = agent.encode(word)
         shuffled = shuffle(n, deck)
         out = agent.decode(shuffled)
 
         if word == out:
             successes += 1
+
+    # Restore stdout
+    sys.stdout = save_stdout
+
     return length, n, successes / pargs.trials
 
 
-lengths = list(range(1, 11))
-shuffle_amounts = list(range(100))
+lengths = list(range(pargs.min_length, pargs.max_length + 1))
+shuffle_amounts = list(range(pargs.min_shuffles, pargs.max_shuffles + 1))
 work = list(product(lengths, shuffle_amounts))
 pool = multiprocessing.Pool(multiprocessing.cpu_count())
+
+print("Collecting results...")
+
 if pargs.disable_threading:
     results = map(run_trial, work)
 else:
     results = pool.imap_unordered(run_trial, work, chunksize=4)
 
-print("Collecting results...")
 collected_results = {}
 for result in results:
     length, n, recovery_rate = result
     if not length in collected_results:
         collected_results[length] = []
     collected_results[length].append((n, recovery_rate))
+
 
 # ======================
 # Plot benchmark results
@@ -100,7 +168,7 @@ for length in collected_results:
     plt.plot(shuffle_amounts, ys, label=str(length))
 
 plt.legend()
-plt.title("Shuffle Count vs. Recovery Rate Across Message Lengths")
+plt.title(f"Shuffle Count vs. Recovery Rate (Agent {pargs.agent})")
 plt.xlabel("Number of shuffles")
 plt.ylabel("Recovery rate")
 plt.savefig("benchmark.png", dpi=300)

--- a/mission.py
+++ b/mission.py
@@ -1,15 +1,8 @@
 import numpy as np
 import cards
 import constants
+from importlib import import_module
 from agents.default import Agent as default_agent
-from agents.agent1 import Agent as agent1
-from agents.agent2 import Agent as agent2
-from agents.agent3 import Agent as agent3
-from agents.agent4 import Agent as agent4
-from agents.agent5 import Agent as agent5
-from agents.agent6 import Agent as agent6
-from agents.agent7 import Agent as agent7
-from agents.agent8 import Agent as agent8
 
 class Mission:
     def __init__(self, args):
@@ -24,7 +17,8 @@ class Mission:
                 self.agent = default_agent()
             else:
                 agent_name = "agent{}".format(args.agent[0])
-                self.agent = eval(agent_name + "()")
+                agent_module = import_module(f".{agent_name}", "agents")
+                self.agent = agent_module.Agent()
         else:
             print("error loading agent ", args.agent[0])
             exit()


### PR DESCRIPTION
This is an automated benchmark script for agents with support for different domains (currently all generated uniformly randomly). Visualized output goes to `benchmark.png`.

I intend for this to be collaborative: as we decide on message domains to target, other students should please feel free to add new message generators.

![image](https://user-images.githubusercontent.com/3701912/198351165-f3e7c2c0-c4ca-4dff-a6ca-b580739e50d3.png)
